### PR TITLE
Use caret range for requiredSdkVersion

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "requiredSdkVersion": "0.1.x",
+  "requiredSdkVersion": "^0.1.0",
   "name": "TypedCaptions",
   "javascriptEntrypointUrl": "TypedCaptions.js",
   "localesBaseUrl": "locales",


### PR DESCRIPTION
Part of the release tweaks: changes `requiredSdkVersion` in `manifest.json` to a caret range (`^x.y.z`), matching the other plugins.

The previous value was the wildcard `0.1.x`. `^0.1.0` expresses the same range (`>=0.1.0 <0.2.0`), and corresponds to the v0.1.x-line equivalent of the `~0.0.59` required on the v0.0.x branch — `v0.0.59` predates the entire 0.1 line, so every 0.1.z release already contains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)